### PR TITLE
Configure The App's Cors Rules 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,4 +54,4 @@ gem 'rubocop', '~> 1.46'
 
 gem 'rswag', '~> 2.8'
 
-gem "rack-cors", "~> 2.0"
+gem 'rack-cors', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ end
 gem 'rubocop', '~> 1.46'
 
 gem 'rswag', '~> 2.8'
+
+gem "rack-cors", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.2)
+    rack-cors (2.0.0)
+      rack (>= 2.0.0)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4.2)
@@ -220,6 +222,7 @@ DEPENDENCIES
   debug
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors (~> 2.0)
   rails (~> 7.0.4, >= 7.0.4.2)
   rspec-rails (~> 6.0)
   rswag (~> 2.8)

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,11 @@ module IModelCarsBackend
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+         origins '*'
+         resource '*', :headers => :any, :methods => [:get, :post, :options]
+       end
+    end
   end
 end


### PR DESCRIPTION
## Overview
In this PR I configured the cors rule for the API by installing the rack-cors gem.
## Workflow
- Install "rack-cors" gem.
- Configure the gem in `application.rb` files.

**S.N: this gem will solve the cross-origin errors when trying to communicate with the API from a different host.**